### PR TITLE
Push bugfix

### DIFF
--- a/packages/core/src/AppManager.ts
+++ b/packages/core/src/AppManager.ts
@@ -16,6 +16,7 @@ import {
   getScopeId,
   swapServerScope
 } from "./server";
+import { PATH_DELIMITER } from "./constants";
 
 const fsp = fs.promises;
 
@@ -261,7 +262,7 @@ class AppManager {
   async pushSpecificFiles(skipPrompt: boolean, pathString: string) {
     if (skipPrompt || (await this.canPush())) {
       let pathPromises = pathString
-        .split(path.delimiter)
+        .split(PATH_DELIMITER)
         .filter(cur => {
           //make sure it isn't blank
           if (cur && cur !== "") {
@@ -450,7 +451,7 @@ class AppManager {
         }
       }
     });
-    return fileArray.join(path.delimiter);
+    return fileArray.join(PATH_DELIMITER);
   }
 
   private getRepoRootDir(): Promise<string> {

--- a/packages/core/src/Watcher.ts
+++ b/packages/core/src/Watcher.ts
@@ -23,8 +23,8 @@ const processQueue = debounce(() => {
             "";
           if (targetServer && payload) {
             pushFile(targetServer, payload)
-              .then(() => {
-                logFilePush(payload, true);
+              .then(result => {
+                logFilePush(payload, result);
               })
               .catch(() => {
                 logFilePush(payload, false);

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,3 @@
+import path from "path";
+
+export const PATH_DELIMITER = `${path.delimiter}${path.delimiter}`;


### PR DESCRIPTION
* Make pushes in dev mode check the result boolean
* Change delimiter to a constant, it will now be two `path.delimiter` values instead of one

Fix #75 
Fix #78 