### PR TITLE
Faster processing of manifest

### DIFF
--- a/packages/core/src/AppManager.ts
+++ b/packages/core/src/AppManager.ts
@@ -57,7 +57,7 @@ class AppManager {
       logger.info("Downloading manifest and files...");
       let man = await getManifestWithFiles(scope);
       logger.info("Creating local files from manifest...");
-      await AppUtils.processManifest(man);
+      await AppUtils.processManifest(man, true);
       logger.success("Download complete ✅");
     } catch (e) {
       logger.error("Encountered error while performing download ❌");

--- a/packages/core/src/FileUtils.ts
+++ b/packages/core/src/FileUtils.ts
@@ -15,7 +15,7 @@ export const SNFileExists = (parentDirPath: string) => async (
   }
 };
 
-const writeSNFileCurry = (checkExists: boolean) => async (
+export const writeSNFileCurry = (checkExists: boolean) => async (
   file: SN.File,
   parentPath: string
 ): Promise<void> => {

--- a/packages/core/src/appUtils.ts
+++ b/packages/core/src/appUtils.ts
@@ -188,7 +188,7 @@ const processMissingFiles = async (newManifest: SN.AppManifest) => {
   try {
     const missing = await findMissingFiles(newManifest);
     const filesToProcess = await SNClient.getMissingFiles(missing);
-    await processTablesInManifest(filesToProcess);
+    await processTablesInManifest(filesToProcess, false);
   } catch (e) {
     throw e;
   }

--- a/packages/core/src/wizard.ts
+++ b/packages/core/src/wizard.ts
@@ -3,6 +3,7 @@ import inquirer from "inquirer";
 import { getAppList, getManifestWithFiles } from "./server";
 import ConfigManager from "./config";
 import AppManager from "./AppManager";
+import * as AppUtils from "./appUtils";
 import fs from "fs";
 const fsp = fs.promises;
 import { logger } from "./Logger";
@@ -124,7 +125,7 @@ async function downloadApp(answers: Sinc.LoginAnswers, scope: string) {
   try {
     let { username: user, password, instance } = answers;
     let man = await getManifestWithFiles(scope, { user, password, instance });
-    await AppManager.processManifest(man);
+    await AppUtils.processManifest(man);
   } catch (e) {
     logger.error(e.toString());
     throw new Error("Failed to download files!");


### PR DESCRIPTION
Rewrote the chain of methods under AppManager.processManifest
* Optimized async code (converted for-loops with await in them)
* Restored missing feature to download command: Forced overwriting of existing files

End result is that processing the manifest is about 4-5x faster now