### PR TITLE
Simplify building and pushing flow

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -6709,9 +6709,10 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -916,12 +916,6 @@
         }
       }
     },
-    "@sincronia/types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sincronia/types/-/types-0.4.0.tgz",
-      "integrity": "sha512-v33TXyXCShLDH5536/O0JG2DHdNbCyfyJbcwcyypdiVLfp7MAx4f194wwXSlB+MOhpbiIS2a4ygyCjetb8MsbQ==",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -5464,9 +5458,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
     },
     "pretty-format": {
       "version": "26.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "dotenv": "^7.0.0",
     "inquirer": "^6.5.0",
     "lodash": "^4.17.15",
-    "prettier": "^1.18.2",
+    "prettier": "2.2.1",
     "progress": "^2.0.3",
     "typescript": "^3.5.3",
     "winston": "^3.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "@types/yargs": "^13.0.0",
     "jest": "^26.0.1",
     "jest-junit": "^10.0.0",
+    "typescript": "^4.1.3",
     "ts-jest": "^26.1.0"
   },
   "dependencies": {
@@ -41,7 +42,6 @@
     "lodash": "^4.17.15",
     "prettier": "2.2.1",
     "progress": "^2.0.3",
-    "typescript": "^3.5.3",
     "winston": "^3.2.1",
     "yargs": "^13.2.4"
   },

--- a/packages/core/src/FileUtils.ts
+++ b/packages/core/src/FileUtils.ts
@@ -10,7 +10,7 @@ export const SNFileExists = (parentDirPath: string) => async (
   try {
     const files = await fsp.readdir(parentDirPath);
     const reg = new RegExp(`${file.name}\..*$`);
-    return !!files.find(f => reg.test(f));
+    return !!files.find((f) => reg.test(f));
   } catch (e) {
     return false;
   }
@@ -78,17 +78,27 @@ export const isUnderPath = (
 
 const getFileExtension = (filePath: string): string => {
   try {
-    return (
-      "." +
-      path
-        .basename(filePath)
-        .split(".")
-        .slice(1)
-        .join(".")
-    );
+    return "." + path.basename(filePath).split(".").slice(1).join(".");
   } catch (e) {
     return "";
   }
+};
+
+export const getBuildExt = (
+  table: string,
+  recordName: string,
+  field: string
+): string => {
+  const manifest = ConfigManager.getManifest();
+  if (!manifest) {
+    throw new Error("Failed to retrieve manifest");
+  }
+  const files = manifest.tables[table].records[recordName].files;
+  const file = files.find((f) => f.name === field);
+  if (!file) {
+    throw new Error("Unable to find file");
+  }
+  return file.type;
 };
 
 export const getBuildExtensions = (context: Sinc.FileContext): SN.TypeMap => {
@@ -136,7 +146,7 @@ export const getFileContextFromPath = (
     const { records } = tables[tableName];
     const record = records[recordName];
     const { files, sys_id } = record;
-    const field = files.find(file => file.name === targetField);
+    const field = files.find((file) => file.name === targetField);
     if (!field) {
       return undefined;
     }
@@ -147,7 +157,7 @@ export const getFileContextFromPath = (
       name: recordName,
       scope,
       tableName,
-      targetField
+      targetField,
     };
   } catch (e) {
     return undefined;
@@ -174,7 +184,7 @@ export const getPathsInPath = async (p: string): Promise<string[]> => {
     return [p];
   } else {
     const childPaths = await fsp.readdir(p);
-    const pathPromises = childPaths.map(childPath =>
+    const pathPromises = childPaths.map((childPath) =>
       getPathsInPath(path.resolve(p, childPath))
     );
     const stackedPaths = await Promise.all(pathPromises);
@@ -183,7 +193,7 @@ export const getPathsInPath = async (p: string): Promise<string[]> => {
 };
 
 export const splitEncodedPaths = (encodedPaths: string): string[] =>
-  encodedPaths.split(PATH_DELIMITER).filter(p => p && p !== "");
+  encodedPaths.split(PATH_DELIMITER).filter((p) => p && p !== "");
 
 export const isValidPath = async (path: string): Promise<boolean> => {
   return pathExists(path);

--- a/packages/core/src/FileUtils.ts
+++ b/packages/core/src/FileUtils.ts
@@ -101,23 +101,6 @@ export const getBuildExt = (
   return file.type;
 };
 
-export const getBuildExtensions = (context: Sinc.FileContext): SN.TypeMap => {
-  const manifest = ConfigManager.getManifest();
-  if (!manifest) {
-    throw new Error("Error reading manifest");
-  }
-  const { tables } = manifest;
-  const table = tables[context.tableName];
-  const recordName = context.name;
-  const record = table.records[recordName];
-  const { files } = record;
-
-  const exts = files.reduce((acc, file) => {
-    return { ...acc, [file.name]: file.type };
-  }, {});
-  return exts;
-};
-
 const getTargetFieldFromPath = (
   filePath: string,
   table: string,

--- a/packages/core/src/Watcher.ts
+++ b/packages/core/src/Watcher.ts
@@ -3,7 +3,7 @@ import { logFilePush } from "./logMessages";
 import { debounce } from "lodash";
 import { getFileContextFromPath } from "./FileUtils";
 import { Sinc } from "@sincronia/types";
-import { groupAppFiles2, pushFiles2 } from "./appUtils";
+import { groupAppFiles, pushFiles } from "./appUtils";
 const DEBOUNCE_MS = 300;
 let pushQueue: string[] = [];
 let watcher: chokidar.FSWatcher | undefined = undefined;
@@ -16,8 +16,8 @@ const processQueue = debounce(async () => {
     const fileContexts = toProcess
       .map(getFileContextFromPath)
       .filter((ctx): ctx is Sinc.FileContext => !!ctx);
-    const buildables = groupAppFiles2(fileContexts);
-    const updateResults = await pushFiles2(buildables);
+    const buildables = groupAppFiles(fileContexts);
+    const updateResults = await pushFiles(buildables);
     updateResults.forEach((res, index) => {
       logFilePush(fileContexts[index], res);
     });

--- a/packages/core/src/appUtils.ts
+++ b/packages/core/src/appUtils.ts
@@ -368,7 +368,7 @@ const getProgTick = (
   total: number
 ): (() => void) | undefined => {
   if (logLevel === "info") {
-    const progBar = new ProgressBar(":bar :current/:total (:percent)", {
+    const progBar = new ProgressBar(":bar (:percent)", {
       total,
       width: 60,
     });

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -171,9 +171,9 @@ export async function buildCommand(args: Sinc.BuildCmdArgs) {
   setLogLevel(args);
   try {
     const encodedPaths = await gitDiffToEncodedPaths(args.diff);
-    const [fileTree, count] = await AppUtils.getFileTreeAndCount(encodedPaths);
-    logger.info(`${count} files to build.`);
-    let results = await AppUtils.buildFiles(fileTree, count);
+    const fileList = await AppUtils.getAppFileList(encodedPaths);
+    logger.info(`${fileList.length} files to build.`);
+    const results = await AppUtils.buildFiles2(fileList);
     logBuildResults(results);
   } catch (e) {
     process.exit(1);

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -124,7 +124,7 @@ export async function pushCommand(args: Sinc.PushCmdArgs): Promise<void> {
           `New Update Set Created(${newUpdateSet.name}) sys_id:${newUpdateSet.id}`
         );
       }
-      const pushResults = await AppUtils.pushFiles2(fileList);
+      const pushResults = await AppUtils.pushFiles(fileList);
       logPushResults(pushResults);
     } catch (e) {
       process.exit(1);
@@ -173,7 +173,7 @@ export async function buildCommand(args: Sinc.BuildCmdArgs) {
     const encodedPaths = await gitDiffToEncodedPaths(args.diff);
     const fileList = await AppUtils.getAppFileList(encodedPaths);
     logger.info(`${fileList.length} files to build.`);
-    const results = await AppUtils.buildFiles2(fileList);
+    const results = await AppUtils.buildFiles(fileList);
     logBuildResults(results);
   } catch (e) {
     process.exit(1);
@@ -225,7 +225,7 @@ export async function deployCommand(args: Sinc.SharedCmdArgs): Promise<void> {
       logger.silly(`${paths.length} paths found...`);
       logger.silly(JSON.stringify(paths, null, 2));
       const appFileList = await AppUtils.getAppFileList(paths);
-      const pushResults = await AppUtils.pushFiles2(appFileList);
+      const pushResults = await AppUtils.pushFiles(appFileList);
       logPushResults(pushResults);
     } catch (e) {
       throw e;

--- a/packages/core/src/snClient.ts
+++ b/packages/core/src/snClient.ts
@@ -33,18 +33,18 @@ export const processPushResponse = (
   if (status === 404) {
     return {
       success: false,
-      message: `Could not find ${recSummary} on the server.`
+      message: `Could not find ${recSummary} on the server.`,
     };
   }
   if (status < 200 || status > 299) {
     return {
       success: false,
-      message: `Failed to push ${recSummary}. Recieved an unexpected response (${status})`
+      message: `Failed to push ${recSummary}. Recieved an unexpected response (${status})`,
     };
   }
   return {
     success: true,
-    message: `${recSummary} pushed successfully!`
+    message: `${recSummary} pushed successfully!`,
   };
 };
 
@@ -58,12 +58,12 @@ export const snClient = (
       withCredentials: true,
       auth: {
         username,
-        password
+        password,
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
       },
-      baseURL
+      baseURL,
     }),
     { maxRPS: 20 }
   );
@@ -101,8 +101,8 @@ export const snClient = (
     return client.get<ScopeResponse>(endpoint, {
       params: {
         sysparm_query: `scope=${scopeName}`,
-        sysparm_fields: "sys_id"
-      }
+        sysparm_fields: "sys_id",
+      },
     });
   };
 
@@ -112,8 +112,8 @@ export const snClient = (
     return client.get<UserResponse>(endpoint, {
       params: {
         sysparm_query: `user_name=${userName}`,
-        sysparm_fields: "sys_id"
-      }
+        sysparm_fields: "sys_id",
+      },
     });
   };
 
@@ -123,8 +123,8 @@ export const snClient = (
     return client.get<UserPrefResponse>(endpoint, {
       params: {
         sysparm_query: `user=${userSysId}^name=apps.current_app`,
-        sysparm_fields: "sys_id"
-      }
+        sysparm_fields: "sys_id",
+      },
     });
   };
 
@@ -142,7 +142,7 @@ export const snClient = (
       value: appSysId,
       name: "apps.current_app",
       type: "string",
-      user: userSysId
+      user: userSysId,
     });
   };
 
@@ -156,7 +156,7 @@ export const snClient = (
     const endpoint = `api/now/table/sys_update_set`;
     type UpdateSetCreateResponse = Sinc.SNAPIResponse<SN.UpdateSetRecord>;
     return client.post<UpdateSetCreateResponse>(endpoint, {
-      name: updateSetName
+      name: updateSetName,
     });
   };
 
@@ -166,8 +166,8 @@ export const snClient = (
     return client.get<CurrentUpdateSetResponse>(endpoint, {
       params: {
         sysparm_query: `user=${userSysId}^name=sys_update_set`,
-        sysparm_fields: "sys_id"
-      }
+        sysparm_fields: "sys_id",
+      },
     });
   };
   const updateCurrentUpdateSetUserPref = (
@@ -187,7 +187,7 @@ export const snClient = (
       value: updateSetSysId,
       name: "sys_update_set",
       type: "string",
-      user: userSysId
+      user: userSysId,
     });
   };
 
@@ -212,7 +212,7 @@ export const snClient = (
       includes,
       excludes,
       tableOptions,
-      withFiles
+      withFiles,
     });
   };
 
@@ -230,7 +230,7 @@ export const snClient = (
     updateCurrentUpdateSetUserPref,
     createCurrentUpdateSetUserPref,
     getMissingFiles,
-    getManifest
+    getManifest,
   };
 };
 
@@ -238,6 +238,8 @@ export const defaultClient = () => {
   const { SN_USER = "", SN_PASSWORD = "", SN_INSTANCE = "" } = process.env;
   return snClient(`https://${SN_INSTANCE}/`, SN_USER, SN_PASSWORD);
 };
+
+export type SNClient = ReturnType<typeof snClient>;
 
 export const unwrapSNResponse = async <T>(
   clientPromise: AxiosPromise<Sinc.SNAPIResponse<T>>

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -78,9 +78,11 @@ export namespace Sinc {
   }
 
   interface PluginFunc {
-    (context: FileContext, content: string, options: any): Promise<
-      PluginResults
-    >;
+    (
+      context: FileContext,
+      content: string,
+      options: any
+    ): Promise<PluginResults>;
   }
 
   interface PluginResults {
@@ -136,6 +138,24 @@ export namespace Sinc {
   interface SNAPIResponse<T> {
     result: T;
   }
+
+  interface BuildableRecord {
+    table: string;
+    sysId: string;
+    fields: Record<string, Sinc.FileContext>;
+  }
+
+  interface RecBuildFail {
+    success: false;
+    message: string;
+  }
+
+  interface RecBuildSuccess {
+    success: true;
+    builtRec: Record<string, string>;
+  }
+
+  type RecBuildRes = RecBuildFail | RecBuildSuccess;
 }
 
 export namespace SN {


### PR DESCRIPTION
This PR includes changes to make building and pushing flows simpler to understand and to make the progress bars more responsive.

Before this change, the files were built/pushed a table at a time, which resulted in long delays until the progress bar showed up. This change removes the need to wait for a table at a time and process each record individually. This also makes the flow more modular.

Additional info:

- Prettier version has been updated in core package to support latest TS features
- The progress bar now tracks building and pushing as separate steps, this means each record is counted twice. The count was removed from the progress bar to avoid confusion.
- TS got bumped to version 4 for the core package