### PR TITLE
Remove 'use strict' from any file using babel

### DIFF
--- a/packages/babel-preset-servicenow/src/sanitizer.ts
+++ b/packages/babel-preset-servicenow/src/sanitizer.ts
@@ -17,12 +17,24 @@ export default function() {
           isReservedWord(path.node.property.name) &&
           !path.node.computed
         ) {
-          let replacement = t.memberExpression(
+          const replacement = t.memberExpression(
             path.node.object,
             t.stringLiteral(path.node.property.name),
             true
           );
           path.replaceWith(replacement);
+        }
+      },
+      //remove use strict
+      Program: {
+        exit: function exit(path) {
+            const list = path.node.directives;
+            for(let i=list.length-1, it; i>=0 ; i--){
+                it = list[i];
+                if (it.value.value==='use strict'){
+                    list.splice(i,1);
+                }
+            }
         }
       }
     }


### PR DESCRIPTION
'use strict' at the top of ServiceNow files is causing issues when ServiceNow switches how scripts are run, from compiled mode to interpreted mode. It seems compiled mode did not factor in 'use strict' but interpreted mode does, causing the `this` keyword to become undefined. In most cases, this does not play nice with Script Includes. 

This PR handles the removal of 'use strict' from ServiceNow file pushes in the future. 