### PR TITLE
duplicated files warning enhancement

### DIFF
--- a/packages/core/src/appUtils.ts
+++ b/packages/core/src/appUtils.ts
@@ -28,6 +28,9 @@ const processFilesInManRec = async (
   rec.files.forEach((file) => {
     delete file.content;
   });
+  
+  if (rec.is_repetead) 
+    logger.warn("⚠️  " + rec.name + " is duplicated!");
 };
 
 const processRecsInManTable = async (

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -180,6 +180,7 @@ export namespace SN {
     files: File[];
     name: string;
     sys_id: string;
+    is_repetead: boolean;
   }
 
   interface File {


### PR DESCRIPTION
[#53](https://github.com/nuvolo/sincronia/issues/53#issue-522548238) When isRepetead flag is true, it will warn users about duplicated files.
Work with: init and refresh command.

Changes in the [scoped app](https://github.com/luifermoron/sincronia-server-scoped-app/tree/ft-warn-users-duplicated-files) are needed.